### PR TITLE
fix: update vscode launch.json path for .NET 9.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/src/Api/bin/Debug/net8.0/VerticalSliceArchitecture.Api.dll",
+      "program": "${workspaceFolder}/src/Api/bin/Debug/net9.0/VerticalSliceArchitecture.Api.dll",
       "args": [],
       "cwd": "${workspaceFolder}/src/Api",
       "stopAtEntry": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated debug configuration to target .NET 9.0 runtime instead of .NET 8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->